### PR TITLE
Address Lighthouse Warnings

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -39,8 +39,8 @@
     </div>
 
     <script
-        src="https://code.jquery.com/jquery-3.3.1.min.js"
-        integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+        src="https://code.jquery.com/jquery-3.5.1.min.js"
+        integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
         crossorigin="anonymous">
     </script>
     <script src="{{asset "built/main.min.js"}}"></script>

--- a/partials/author.hbs
+++ b/partials/author.hbs
@@ -14,17 +14,17 @@
                     <div class="author-social">
                         {{#if website}}
                             <a class="author-social-item author-website"
-                                href="{{website}}" target="_blank">Website</a>
+                                href="{{website}}" target="_blank" rel="noopener">Website</a>
                         {{/if}}
                         {{#if facebook}}
                             <a class="author-social-item author-facebook"
                                 href="https://www.facebook.com/{{facebook}}"
-                                target="_blank">Facebook</a>
+                                target="_blank" rel="noopener">Facebook</a>
                         {{/if}}
                         {{#if twitter}}
                             <a class="author-social-item author-twitter"
                                 href="https://twitter.com/{{twitter}}"
-                                target="_blank">Twitter</a>
+                                target="_blank" rel="noopener">Twitter</a>
                         {{/if}}
                         <a class="author-social-item author-more"
                             href={{url}}>More posts</a>

--- a/partials/footer.hbs
+++ b/partials/footer.hbs
@@ -1,6 +1,6 @@
 <footer class="site-footer container large">
     <div class="copyright">
-        Powered by <a href="https://ghost.org/" target="_blank">Ghost</a>
+        Powered by <a href="https://ghost.org/" target="_blank" rel="noopener">Ghost</a>
     </div>
 
     {{> logo}}
@@ -8,18 +8,18 @@
     <div class="footer-social">
         {{#if @site.facebook}}
             <a class="footer-social-item footer-social-item-facebook" href="{{facebook_url @site.facebook}}"
-                target="_blank" rel="noopener noreferrer" aria-label="Facebook">
+                target="_blank" rel="noopener" aria-label="Facebook">
                 <i class="icon icon-facebook"></i>
             </a>
         {{/if}}
         {{#if @site.twitter}}
             <a class="footer-social-item footer-social-item-twitter" href="{{twitter_url @site.twitter}}"
-                target="_blank" rel="noopener noreferrer" aria-label="Twitter">
+                target="_blank" rel="noopener" aria-label="Twitter">
                 <i class="icon icon-twitter"></i>
             </a>
         {{/if}}
         <a class="footer-social-item footer-social-item-rss"
-            href="https://feedly.com/i/subscription/feed/{{@site.url}}/rss/" target="_blank" rel="noopener noreferrer"
+            href="https://feedly.com/i/subscription/feed/{{@site.url}}/rss/" target="_blank" rel="noopener"
             aria-label="RSS">
             <i class="icon icon-rss"></i>
         </a>

--- a/partials/post-footer.hbs
+++ b/partials/post-footer.hbs
@@ -2,7 +2,7 @@
     <div class="post-action">
         <a class="post-link primary" href="{{url}}">Read Now</a>
         <a class="post-link secondary" href="https://getpocket.com/edit?url={{url absolute="true"}}"
-            target="_blank">Read Later</a>
+            target="_blank" rel="noopener">Read Later</a>
     </div>
     <div class="post-author">
         {{#foreach authors}}

--- a/partials/share.hbs
+++ b/partials/share.hbs
@@ -1,28 +1,28 @@
 <div class="share u-hover-wrapper">
     <a class="share-item share-facebook u-hover-item"
-        href="https://www.facebook.com/sharer.php?u={{url absolute="true"}}" target="_blank"><i
+        href="https://www.facebook.com/sharer.php?u={{url absolute="true"}}" target="_blank" rel="noopener"><i
             class="icon icon-facebook"></i></a>
     <a class="share-item share-twitter u-hover-item"
-        href="https://twitter.com/intent/tweet?url={{url absolute="true"}}&text={{encode title}}" target="_blank"><i
+        href="https://twitter.com/intent/tweet?url={{url absolute="true"}}&text={{encode title}}" target="_blank" rel="noopener"><i
             class="icon icon-twitter"></i></a>
     <a class="share-item share-pinterest u-hover-item"
         href="https://pinterest.com/pin/create/button/?url={{url absolute="true"}}&media={{featured_image}}&description={{encode title}}"
-        target="_blank" data-pin-do="none"><i class="icon icon-pinterest"></i></a>
+        target="_blank" rel="noopener" data-pin-do="none"><i class="icon icon-pinterest"></i></a>
     <a class="share-item share-linkedin u-hover-item"
         href="https://www.linkedin.com/shareArticle?mini=true&url={{url absolute="true"}}&title={{encode title}}"
-        target="_blank"><i class="icon icon-linkedin"></i></a>
+        target="_blank" rel="noopener"><i class="icon icon-linkedin"></i></a>
     <a class="share-item share-reddit u-hover-item"
-        href="https://reddit.com/submit?url={{url absolute="true"}}&title={{encode title}}" target="_blank"><i
+        href="https://reddit.com/submit?url={{url absolute="true"}}&title={{encode title}}" target="_blank" rel="noopener"><i
             class="icon icon-reddit"></i></a>
     <a class="share-item share-tumblr u-hover-item"
         href="https://www.tumblr.com/widgets/share/tool?canonicalUrl={{url absolute="true"}}&title={{encode title}}"
-        target="_blank"><i class="icon icon-tumblr"></i></a>
+        target="_blank" rel="noopener"><i class="icon icon-tumblr"></i></a>
     <a class="share-item share-vk u-hover-item"
-        href="http://vk.com/share.php?url={{url absolute="true"}}&title={{encode title}}" target="_blank"><i
+        href="http://vk.com/share.php?url={{url absolute="true"}}&title={{encode title}}" target="_blank" rel="noopener"><i
             class="icon icon-vk"></i></a>
     <a class="share-item share-pocket u-hover-item" href="https://getpocket.com/edit?url={{url absolute="true"}}"
-        target="_blank"><i class="icon icon-pocket"></i></a>
+        target="_blank" rel="noopener"><i class="icon icon-pocket"></i></a>
     <a class="share-item share-telegram u-hover-item"
-        href="https://t.me/share/url?url={{url absolute="true"}}&text={{encode title}}" target="_blank"><i
+        href="https://t.me/share/url?url={{url absolute="true"}}&text={{encode title}}" target="_blank" rel="noopener"><i
             class="icon icon-telegram"></i></a>
 </div>


### PR DESCRIPTION
While deploying Alto into a staging environment, I ran a Lighthouse check against it and noticed a few things seem to have slipped through the cracks when compared to Casper. This pull requests addresses the following:

- jQuery has been updated from 3.3.1 to 3.5.1
- Added `rel="noopener"` to all external links

I have tested these changes on my local Ghost instance, and have not noticed any negative side effects.