### PR TITLE
Load dark mode if system preferences are set to dark mode by default

### DIFF
--- a/assets/css/misc/utilities.css
+++ b/assets/css/misc/utilities.css
@@ -209,3 +209,21 @@
         padding-bottom: 62.5%;
     }
 }
+
+html {
+    content: ""; /* (ab)using the content property */
+}
+
+/* Light mode */
+@media (prefers-color-scheme: light) {
+    html {
+        content: "light"; /* (ab)using the content property */
+    }
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    html {
+        content: "dark"; /* (ab)using the content property */
+    }
+}

--- a/default.hbs
+++ b/default.hbs
@@ -9,9 +9,19 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli:400,400i,700,700i,800">
 
     <script>
-        if (localStorage.getItem('alto_dark') == 'true') {
-            document.documentElement.classList.add('dark-mode');
+        const updateDarkMode = () => {
+            const mode = getComputedStyle(document.documentElement).getPropertyValue('content');
+
+            if (localStorage.getItem('alto_dark') == 'true' ||
+                (mode === 'dark' && localStorage.getItem('alto_dark') === null)) {
+                document.documentElement.classList.add('dark-mode');
+            } else if(mode === 'light' && localStorage.getItem('alto_dark') === null) {
+                document.documentElement.classList.remove('dark-mode');
+            }
         }
+        updateDarkMode();
+        window.matchMedia('(prefers-color-scheme: light)').addListener(updateDarkMode);
+        window.matchMedia('(prefers-color-scheme: dark)').addListener(updateDarkMode);
     </script>
 
     {{ghost_head}}


### PR DESCRIPTION
This is a way to have dark mode automatically load for a new site visitor when a visitor's system preferences are set to dark mode. Once a user clicks the toggle, the toggle settings specified in local storage will be loaded as default.

I have it working in my fork, so I thought I'd just make this PR in case you'd like to use it in any way. No worries if not - feel free to close without merging if it isn't aligned with your vision for the theme. I'm still new to the frontend world, and am happy to revise my code to be less hacky if there's a better way

This is a video of it:
https://www.loom.com/share/ecd714977f834132ac2cdea469bee3d9

The `window.matchMedia` listener will be ignored if the browser doesn't support it. 

Next steps would be to show a checkbox in the ghost dashboard for admin users to set `use system preferences for dark mode` so they can choose to toggle this feature on or off.

Cheers, thanks for the great theme
