### PR TITLE
fix: don't encode src before zipping

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,7 +84,7 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!yarn-error.log'
-        ]),
+        ], {encoding: false}),
         zip(filename),
         dest('dist/')
     ], handleError(done));


### PR DESCRIPTION
I have been trying to figure out why my images have not been showing, turns out there's an issue copying files before zipping: https://github.com/gulpjs/gulp/issues/2777#issuecomment-2036776560

This fixes the issue with images.